### PR TITLE
Set EDGE_MODE=development before running package prepare scripts

### DIFF
--- a/index.js
+++ b/index.js
@@ -163,7 +163,7 @@ async function main () {
     chdir(requirePath)
     if (typeof packageJson.scripts !== 'undefined') {
       if (typeof packageJson.scripts.prepare !== 'undefined') {
-        call('npm run prepare')
+        call('EDGE_MODE=development npm run prepare')
       }
     }
 


### PR DESCRIPTION
The EDGE_MODE is the "execution mode" for the process.
It is a rename of the conventional NODE_ENV, but the new name scopes
the variable to Edge projects to avoid any collision whatsoever.